### PR TITLE
refactor: use `bringToFront` for stack navigation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/judahben149/tala/navigation/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/judahben149/tala/navigation/RootComponent.kt
@@ -2,6 +2,7 @@ package com.judahben149.tala.navigation
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.navigate
 import com.arkivanov.decompose.router.stack.pop
@@ -33,7 +34,7 @@ class RootComponent(
                     onButtonClick = { textFromFirstScreen ->
                         navigation.pushNew(Configuration.LoginScreen)
                     },
-                    onNavigateToLogin = { navigation navigateTo Configuration.LoginScreen },
+                    onNavigateToLogin = { navigation.bringToFront(Configuration.LoginScreen) },
                     onNavigateToHome = { navigation navigateTo Configuration.HomeScreen }
                 )
             )
@@ -43,7 +44,7 @@ class RootComponent(
                     componentContext = componentContext,
                     onBackButtonClick = { navigation.pop() },
                     onNavigateToHome = { navigation navigateTo Configuration.HomeScreen },
-                    onNavigateToSignUp = { navigation navigateTo Configuration.SignUpScreen }
+                    onNavigateToSignUp = { navigation.bringToFront(Configuration.SignUpScreen) }
                 )
             )
 


### PR DESCRIPTION
This commit updates the navigation logic in `RootComponent.kt` to use `bringToFront` instead of `navigateTo` when navigating between the `SignUpScreen` and `LoginScreen`.

This change ensures that if a screen already exists in the navigation stack, it is brought to the front instead of creating a new instance.