### PR TITLE
feat: implement iOS audio player

### DIFF
--- a/composeApp/src/iosMain/kotlin/com/judahben149/tala/data/service/audio/IosAudioPlayer.kt
+++ b/composeApp/src/iosMain/kotlin/com/judahben149/tala/data/service/audio/IosAudioPlayer.kt
@@ -1,0 +1,63 @@
+package com.judahben149.tala.data.service.audio
+
+import co.touchlab.kermit.Logger
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.AVFAudio.AVAudioPlayer
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayback
+import platform.AVFAudio.setActive
+import platform.Foundation.NSData
+import platform.Foundation.dataWithBytes
+
+class IosAudioPlayer(
+    private val logger: Logger
+): SpeechPlayer {
+    private var player: AVAudioPlayer? = null
+
+    @OptIn(ExperimentalForeignApi::class)
+    override suspend fun load(bytes: ByteArray, mimeType: String) {
+        // Activate audio session
+        val session = AVAudioSession.sharedInstance()
+        session.setCategory(AVAudioSessionCategoryPlayback, error = null)
+        session.setActive(true, error = null)
+
+        val data = bytes.toNSData()
+        // Let AVAudioPlayer detect format from data; if needed, supply fileTypeHint (e.g., "mp3")
+        player = AVAudioPlayer(data = data, fileTypeHint = null, error = null)
+        player?.prepareToPlay()
+    }
+
+    override fun play() {
+        logger.d { "ios player is playing stuff now" }
+        player?.play()
+    }
+    override fun pause() { player?.pause() }
+    override fun stop() { player?.stop() }
+    override fun isPlaying(): Boolean = player?.playing == true
+}
+
+actual class AudioPlayerFactory actual constructor() {
+    fun create(logger: Logger): SpeechPlayer = IosAudioPlayer(logger)
+
+    actual fun create(): SpeechPlayer {
+        throw IllegalStateException("Use create(context) on Android")
+    }
+}
+
+// Helper
+//@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+//private fun ByteArray.toNSData(): NSData = memScoped {
+//    NSData.create(bytes = this@toNSData.refTo(0) as COpaquePointer?, length = this@toNSData.size.toULong())
+//}
+
+@OptIn(ExperimentalForeignApi::class)
+fun ByteArray.toNSData(): NSData {
+    return this.usePinned { pinned ->
+        NSData.dataWithBytes(
+            bytes = pinned.addressOf(0),
+            length = this.size.toULong()
+        )
+    }
+}


### PR DESCRIPTION
This commit introduces an `IosAudioPlayer` implementation for playing audio on iOS devices.

**Key Changes:**

- **`IosAudioPlayer.kt`:**
    - Created a new class `IosAudioPlayer` that implements the `SpeechPlayer` interface.
    - Uses `AVAudioPlayer` from `platform.AVFAudio` for audio playback.
    - **`load(bytes: ByteArray, mimeType: String)`:**
        - Activates the `AVAudioSession` with `AVAudioSessionCategoryPlayback`.
        - Converts the input `ByteArray` to `NSData` using a helper extension function. - Initializes `AVAudioPlayer` with the audio data. - Calls `prepareToPlay()` on the player.
    - **`play()`:** Calls `player?.play()`. Includes logging.
    - **`pause()`:** Calls `player?.pause()`.
    - **`stop()`:** Calls `player?.stop()`.
    - **`isPlaying()`:** Returns `player?.playing == true`.
- **`AudioPlayerFactory.ios.kt` (within `IosAudioPlayer.kt`):**
    - Updated the `actual class AudioPlayerFactory` for iOS.
    - Added a `create(logger: Logger)` function that returns an instance of `IosAudioPlayer`.
    - The existing `create()` function now throws an `IllegalStateException` as it's not applicable for iOS in this context.
- **`ByteArray.toNSData()` Extension:**
    - Added an extension function to convert a `ByteArray` to `NSData` using `usePinned` and `dataWithBytes`. This is necessary for passing audio data to `AVAudioPlayer`.